### PR TITLE
Fixing issue with type and ID length parsing

### DIFF
--- a/NdefLibrary/Classes/NdefMessage.swift
+++ b/NdefLibrary/Classes/NdefMessage.swift
@@ -205,6 +205,7 @@ public struct NdefMessageParsingError: Error {
                     throw NdefMessageParsingError(index: recordStartIndex, rawBytes: rawMessage, kind: .typeFieldMissing)
                 }
                 type = Array(rawMessage[typeIndex..<(typeIndex + typeLength)])
+                typeIndex += typeLength - 1
             }
             
             var idIndex = typeIndex
@@ -214,6 +215,7 @@ public struct NdefMessageParsingError: Error {
                     throw NdefMessageParsingError(index: recordStartIndex, rawBytes: rawMessage, kind: .idFieldMissing)
                 }
                 id = Array(rawMessage[idIndex..<(idIndex + idLength)])
+                idIndex += idLength - 1
             }
             
             var payloadEndIndex = idIndex


### PR DESCRIPTION
This PR fixes an issue where parsing the NDEF message would be incorrect for Type and ID length greater than 1.

Just needed to take their respective length into consideration.